### PR TITLE
Use removeAt instead removeFirst

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/KNewCameraActivity.kt
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/KNewCameraActivity.kt
@@ -299,7 +299,7 @@ class KNewCameraActivity : Fragment() {
                             val face = faces[0]
                             faceObjects.add(face)
                             if (faceObjects.size > 15) {
-                                faceObjects.removeFirst()
+                                faceObjects.removeAt(0)
                                 // Euler Y angle represents the rotation around the vertical axis.
                                 val eulerY: Double = (faceObjects.sumOf { it.headEulerAngleY.toDouble() }) / faceObjects.size
                                 val bounds: Rect = face.boundingBox

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@capacitor-community/camera-preview",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@capacitor-community/camera-preview",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/camera-preview",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Camera preview",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Fix para prevenir issues en versiones de Android viejas.